### PR TITLE
fix host detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,7 @@ module.exports = {
       require('ms-signalr-client');
       signalRHubConnectionFunc = window.jQuery.hubConnection;
     }
-    const protocol = serverUrl.split('//')[0];
-    const host = serverUrl.split('//')[1];
+    const [protocol, host] = serverUrl.split(/\/\/|\//);
     window.location = {
       protocol: protocol,
       host: host


### PR DESCRIPTION
If server URL contains something some path after host (e.g. http://react-native-signalr.azurewebsites.net/signalr) behaviour of shim's url parser differs from browser's.